### PR TITLE
chore: cross-compile pass-api

### DIFF
--- a/apps/pass-api/Dockerfile
+++ b/apps/pass-api/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22
+FROM --platform=${BUILDPLATFORM} golang:1.22 AS builder
 
 ARG GIT_COMMIT_SHA
 ARG GIT_REPOSITORY_URL
@@ -14,9 +14,20 @@ RUN go mod download
 
 # App
 COPY *.go ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o /app/pass-api
+ARG TARGETPLATFORM
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETPLATFORM#*/}" go build \
+    -ldflags="-s -w" -trimpath -o /app/pass-api
 
 # Migrations
 COPY migrations /app/migrations/
 
-CMD ["/app/pass-api"]
+# Release stage (minimal image)
+FROM scratch
+
+# Set the workdir
+WORKDIR /app
+
+COPY --from=builder /app/pass-api /app/pass-api
+COPY --from=builder /app/migrations /app/migrations
+
+CMD ["./pass-api"]


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
uses golang's cross-compiler to build `pass-api`, rather than buildx target emulation. This makes things faster. It also switches to using `scratch` as the base of the runtime image, to make things smaller at runtime.

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
