### PR TITLE
chore: Pass full commit SHA to services at runtime, not short SHA

### DIFF
--- a/.github/workflows/main-autorelease.yaml
+++ b/.github/workflows/main-autorelease.yaml
@@ -236,4 +236,4 @@ jobs:
       # Args to script: push for "dev" environment to the "dev" branch
       - name: Update Dev Branch
         run: |          
-          ./scripts/update_deploy_branch.sh ${{ env.COMMIT_SHA }} dev dev
+          ./scripts/update_deploy_branch.sh ${{ env.COMMIT_SHA_FULL }} dev dev


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

We give the full commit SHA to services at runtime for their telemetry, as this is necessary for DD source integration to match the code up.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
